### PR TITLE
Catch segfaults in Alternating knots and Improve GetSmallGirthMorseCode

### DIFF
--- a/ComputeHFKv2/Diagrams.cpp
+++ b/ComputeHFKv2/Diagrams.cpp
@@ -140,8 +140,7 @@ MorseCode PlanarDiagram::GetSmallGirthMorseCode(int MaxNumberOfTries) const {
 	       }  
 	    int aa=sizeAsInt(MostConnected);
              if (aa == 0) { //problem with planar diagram
-               vector<int> Empty =vector<int>();
-	       return MorseCode(Empty, -1);
+                continue;
 	     }     
              int a1=rand()% aa;
              int NextC =MostConnected[a1]; 
@@ -204,6 +203,11 @@ MorseCode PlanarDiagram::GetSmallGirthMorseCode(int MaxNumberOfTries) const {
 	 if(B < SmallestGirth || (B==SmallestGirth  &&  TempComplexity< Complexity ))//saving the impoved MorseList:
            {SmallestGirth=B;  Complexity=TempComplexity; MorseList=TempMorseList;}
 	}
+
+    if(MorseList.empty())
+      {vector<int> Empty =vector<int>();
+       return MorseCode(Empty, -1);
+      }
         
     return MorseCode(MorseList, SmallestGirth);
 }

--- a/ComputeHFKv2/PyWrapper.cpp
+++ b/ComputeHFKv2/PyWrapper.cpp
@@ -217,12 +217,6 @@ PyObject *PDCodeToHFK(const char *pd, int prime, bool complex)
 
   _InitializeMonomialStoreAndMap();
 
-  const MorseCode LastCheckBeforeComputation = diag.GetSmallGirthMorseCode(1);
-  if (LastCheckBeforeComputation.GetMorseList().empty()) {
-      py::RaiseValueError("Could not compute a small girth Morse code");
-      return nullptr;
-  }
-
   if(diag.Alternating() && !complex) {
       py::object o = KnotFloerForAlternatingKnotsAsDict(diag, prime);
       return o.StealObject();

--- a/ComputeHFKv2/PyWrapper.cpp
+++ b/ComputeHFKv2/PyWrapper.cpp
@@ -98,6 +98,10 @@ static py::object MorseCodeAsEvents(const MorseCode &code)
 
 static py::object KnotFloerForAlternatingKnotsAsDict(PlanarDiagram Diag, int prime) {
   vector<int> Morse = Diag.GetSmallGirthMorseCode(200).GetMorseList();
+  if (Morse.empty()) {
+    py::RaiseValueError("Could not compute a small girth Morse code");
+    return nullptr;
+  }
   Bridge=1;
   Term G1; G1.Alexander = 0; G1.Coeff = 1; G1.Idem = 2;
   vector<Term> Current; Current.push_back(G1);


### PR DESCRIPTION
The previous commits fixed the segfaulting issue for nonalternating knots, but since alternating knots get treated separately, a separate check was needed in that function to see if the returned Morse code is empty.

The changes to diag.GetSmallGirthMorseCode allow it to continue new random attempts to find a small girth Morse code when an invalid state is reached rather than immediately giving up.  An empty MorseCode is only returned if an invalid state is reached on every attempt.

In my testing this decreased the number of times that an exception was raised to essentially zero. 